### PR TITLE
Fix exception in GenerateCommitMessage()

### DIFF
--- a/ac2git.py
+++ b/ac2git.py
@@ -1973,7 +1973,8 @@ class AccuRev2Git(object):
             raise Exception("Unrecognized git message style '{s}'".format(s=style))
 
         if cherryPickSrcHash is not None:
-            messageSections[0] = "(CP) {0}".format(messageSections[0])
+            if len(messageSections) > 0:
+                messageSections[0] = "(CP) {0}".format(messageSections[0])
             messageSections.append("(cherry picked from commit {hash})".format(hash=cherryPickSrcHash))
 
         return ('\n\n'.join(messageSections), notes)


### PR DESCRIPTION
Empty commit messages for cherry-pick commits seem
to cause an exception to be thrown. This is due
to the messages being incorrectly parsed.

Resolves: issue #73