### PR TITLE
Fix multiple mkstream transactions with same timestamp

### DIFF
--- a/accurev.py
+++ b/accurev.py
@@ -322,13 +322,13 @@ class obj:
             self.Type                  = Type
             self.basis                 = basis
             self.basisStreamNumber     = IntOrNone(basisStreamNumber)
-            self.time                  = UTCDateTimeOrNone(time)
+            self.time                  = UTCDateTimeOrNone(time)           # Represents the timelock
             self.prevTime              = UTCDateTimeOrNone(prevTime)
             self.prevBasis             = prevBasis
             self.prevBasisStreamNumber = IntOrNone(prevBasisStreamNumber)
             self.prevName              = prevName
             self.workspace             = workspace
-            self.startTime             = UTCDateTimeOrNone(startTime)
+            self.startTime             = UTCDateTimeOrNone(startTime)      # The time at which the last mkstream or chstream transaction was recorded for this stream
             self.isDynamic             = obj.Bool.fromstring(isDynamic)
             self.hasDefaultGroup       = obj.Bool.fromstring(hasDefaultGroup)
     


### PR DESCRIPTION
One underlying assumption made in `accurev.py` in the function
`get_mkstream_transaction()` - which is intended to account for quirks found in
older Accurev depots - was that multiple Accurev transactions can not occur at
the same timestamp. As this assumption was incorrect it has now been fixed.

Resolves: issue #85