### PR TITLE
Error message should hint at a workaround when it can't recover

### DIFF
--- a/ac2git.py
+++ b/ac2git.py
@@ -3170,6 +3170,8 @@ class AccuRev2Git(object):
                 logger.info( "Created a new git repository." )
             else:
                 logger.error( "Failed to create a new git repository." )
+                logger.error( "Try to create it manually using git and then restart:" )
+                logger.error( "    git init {0}".format(gitRepoPath) )
                 sys.exit(1)
                 
             return True


### PR DESCRIPTION
Add a message providing possible workarounds when we fail to create a Git repository.