### PR TITLE
Fixed dealing with readonly files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,4 @@ FakesAssemblies/
 *.log
 *.config.xml
 
+.idea/

--- a/ac2git.py
+++ b/ac2git.py
@@ -452,8 +452,8 @@ class AccuRev2Git(object):
                 os.unlink(path)
             elif os.path.isfile(path):
                 try:
-                    os.remove(path)
-                except:
+                    os.unlink(path)
+                except OSError:
                     os.chmod(path, stat.S_IWRITE )
                     os.unlink(path)
             elif os.path.isdir(path):

--- a/ac2git.py
+++ b/ac2git.py
@@ -27,6 +27,7 @@ import codecs
 import json
 import pytz
 import tempfile
+import stat
 
 from collections import OrderedDict
 
@@ -450,7 +451,11 @@ class AccuRev2Git(object):
             if os.path.islink(path):
                 os.unlink(path)
             elif os.path.isfile(path):
-                os.remove(path)
+                try:
+                    os.remove(path)
+                except:
+                    os.chmod(path, stat.S_IWRITE )
+                    os.unlink(path)
             elif os.path.isdir(path):
                 shutil.rmtree(path)
             


### PR DESCRIPTION
Script would crash when a file in AccuRev was set as read only. 

PermissionError: [WinError 5] Access is denied: 'D:\\path\\to\\readonly\\file.txst'

This change catches the exception and then removes the readonly flag, and tries to delete the file a second time.

Note: I ran into this problem on Win7, Py 3.4, AccuRev 7.0, Git 2.16.1.windows.1